### PR TITLE
Add .lean() to get only the properties of the document, and save memory

### DIFF
--- a/gnx.js
+++ b/gnx.js
@@ -422,9 +422,10 @@ const onUpdateSubject = async function (Model, gqltype, args, session, linkToPar
   }
 
   let modifiedObject = materializedModel.modelArgs
-  const currentObject = await Model.findById({ _id: objectId })
+  const currentObject = await Model.findById({ _id: objectId }).lean()
 
   const argTypes = gqltype.getFields()
+
   for (const fieldEntryName in argTypes) {
     const fieldEntry = argTypes[fieldEntryName]
     if (fieldEntry.extensions && fieldEntry.extensions.relation && fieldEntry.extensions.relation.embedded) {


### PR DESCRIPTION
when the currentObject is obtained to use later to create a modified object, if we don't use .lean( ) in findById() method you get other unnecessary data that cause error.